### PR TITLE
Added docker to handle the redis server and celery tasks

### DIFF
--- a/Dockerfile-app
+++ b/Dockerfile-app
@@ -1,0 +1,6 @@
+FROM python:3.9-alpine
+ADD . /code
+WORKDIR /code
+RUN apk add build-base
+RUN pip install -r requirements.txt
+CMD ["sh", "run.sh"]

--- a/Dockerfile-celery
+++ b/Dockerfile-celery
@@ -1,0 +1,7 @@
+FROM python:3.9-alpine
+WORKDIR /code
+ADD . /code
+ENV DOCKER_IN_USE=yes
+RUN apk add build-base
+RUN pip install -r requirements.txt
+CMD ["celery", "-A", "monolith.background", "worker", "-l", "INFO", "-B"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,32 @@
+version: '3'
+
+services:
+  monolith:
+    container_name: monolith
+    build:
+      context: .
+      dockerfile: Dockerfile-app
+    ports:
+      - "5000:5000"
+    volumes:
+      - .:/code
+    depends_on:
+      - redis
+
+  celery:
+    container_name: celery
+    build:
+      context: .
+      dockerfile: Dockerfile-celery
+    volumes:
+      - .:/code
+    depends_on:
+      - redis
+    links:
+      - redis
+
+  redis:
+      container_name: redis
+      image: "redis:alpine"
+      ports:
+        - "6379:6379"

--- a/monolith/background.py
+++ b/monolith/background.py
@@ -1,4 +1,5 @@
 from os import name
+import os
 import re
 from celery import Celery
 from celery.schedules import crontab
@@ -11,7 +12,12 @@ import random
 _APP = None
 MIN_LOTTERY_POINTS = 1
 MAX_LOTTERY_POINTS = 5
-BACKEND = BROKER = 'redis://localhost:6379'
+
+if os.environ.get('DOCKER_IN_USE') is not None:
+    BACKEND = BROKER = 'redis://redis:6379'
+else:
+    BACKEND = BROKER = 'redis://localhost:6379'
+
 celery = Celery(__name__, backend=BACKEND, broker=BROKER,
                 include=['monolith.tasks.new_message_tasks', 'monolith.message_logic']) # include these files in the tasks of celery
 

--- a/run.sh
+++ b/run.sh
@@ -3,4 +3,4 @@
 export FLASK_APP=monolith
 export FLASK_ENV=development
 export FLASK_DEBUG=true
-flask run
+flask run --host 0.0.0.0


### PR DESCRIPTION
3 main files have been addes:
- docker-conpose.yml: defines 3 containers (monolith, celery and redis) that will be created.
- Dockerfile-app: is the dockerfile used to start the app
- Dockerfile-celery: is the dockerfile used to start a celery worker

background.py has been modified to use an environmental varibale (DOCKER_IN_USE) to define the backend and the brocker in case the application is running with docker or in localhost